### PR TITLE
Experimental support for 2 and 3 using six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nose
 unittest2
 bumpversion
+six

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@
 import os
 import sys
 import json
-import urllib
+#import urllib
+from six.moves.urllib.request import urlretrieve
 import tarfile
 import logging
 import subprocess
@@ -209,7 +210,7 @@ class node_build(_build):
             os.makedirs(node_src_dir)
 
         try:
-            filename, __ = urllib.urlretrieve(node_url)
+            filename, __ = urlretrieve(node_url)
         except IOError:
             raise IOError(
                 "cannot download node source from '%s'" % (node_url,)


### PR DESCRIPTION
I do see what you mean now though with the node configure:

```
...
    INFO:virtual-node:b'      ^'
    INFO:virtual-node:b"SyntaxError: Missing parentheses in call to 'print'"
    CRITICAL:virtual-node:b'  File "./configure", line 319'
...
```

This was more an example of using six as a prototype solution.
